### PR TITLE
Display 000 in code as missing

### DIFF
--- a/infgen.c
+++ b/infgen.c
@@ -1185,8 +1185,11 @@ local int dynamic(struct state *s) {
         lengths[order[index]] = len;
         if (s->binary)
             putc(len + 1, s->out);
-        if (s->draw && len) {
-            s->col = fprintf(s->out, "code %d %d", order[index], len);
+        if (s->draw) {
+            if (len)
+                s->col = fprintf(s->out, "code %d %d", order[index], len);
+            else
+                s->col = fprintf(s->out, "code %d missing", order[index]);
             putbits(s);
         }
     }


### PR DESCRIPTION
It may be helpful to display codes missing in the block (indicated by length 000) as missing.

By `cat infgen.c | gzip -9 | ./infgen -idds >dump.txt`, infgen formerly emitted
```
code 11 4		! 100
code 4 5		! 101
code 12 4		! 100
code 13 5		! 101 000
zeros 10		! 111 0111111
lens 7			! 010
```

It now emits
```
code 11 4		! 100
code 4 5		! 101
code 12 4		! 100
code 3 missing		! 000
code 13 5		! 101
zeros 10		! 111 0111111
lens 7			! 010
```
instead.